### PR TITLE
Whitespace ignored in keepfiles

### DIFF
--- a/src/keepfile.rs
+++ b/src/keepfile.rs
@@ -49,7 +49,7 @@ impl KeepFile {
             // Filter out invalid lines
             .filter_map(|(num, line)| line.ok().map(|line| (num, line)))
             // Parse the lines into numbers, or return an error
-            .map(|(num, line)| match line.parse() {
+            .map(|(num, line)| match line.trim().parse() {
                 Ok(ord) => Ok(KeepFileLine(ord)),
                 Err(_) => Err(KeepFileBadLine(num + 1, line)),
             })


### PR DESCRIPTION
Added `.trim()` call before parsing each keepfile line, in order to ignore leading and trailing whitespace